### PR TITLE
occlude labels, format values, color by secondary measure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1102,11 +1102,32 @@
       "integrity": "sha512-sdBMGfNvLUkBypPMEhOcKcblTQfgHbqbYrUqRE31jOwdDHBJBxz4co2MDAq93S4Cp++phk4UiwoEg/1hK3xXAQ==",
       "dev": true
     },
+    "@types/d3-color": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-2.0.1.tgz",
+      "integrity": "sha512-u7LTCL7RnaavFSmob2rIAJLNwu50i6gFwY9cHFr80BrQURYQBRkJ+Yv47nA3Fm7FeRhdWTiVTeqvSeOuMAOzBQ==",
+      "dev": true
+    },
+    "@types/d3-format": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-2.0.0.tgz",
+      "integrity": "sha512-uagdkftxnGkO4pZw5jEYOM5ZnZOEsh7z8j11Qxk85UkB2RzfUUxRl7R9VvvJZHwKn8l+x+rpS77Nusq7FkFmIg==",
+      "dev": true
+    },
     "@types/d3-hierarchy": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-2.0.0.tgz",
       "integrity": "sha512-YxdskUvwzqggpnSnDQj4KVkicgjpkgXn/g/9M9iGsiToLS3nG6Ytjo1FoYhYVAAElV/fJBGVL3cQ9Hb7tcv+lw==",
       "dev": true
+    },
+    "@types/d3-interpolate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-2.0.0.tgz",
+      "integrity": "sha512-Wt1v2zTlEN8dSx8hhx6MoOhWQgTkz0Ukj7owAEIOF2QtI0e219paFX9rf/SLOr/UExWb1TcUzatU8zWwFby6gg==",
+      "dev": true,
+      "requires": {
+        "@types/d3-color": "*"
+      }
     },
     "@types/d3-scale": {
       "version": "3.2.2",
@@ -2084,6 +2105,11 @@
         "kind-of": "^6.0.2",
         "shallow-clone": "^3.0.0"
       }
+    },
+    "clsx": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
     },
     "collection-visit": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "@babel/core": "^7.13.10",
     "@babel/preset-env": "^7.13.10",
     "@types/d3-array": "^2.9.0",
+    "@types/d3-format": "^2.0.0",
     "@types/d3-hierarchy": "^2.0.0",
+    "@types/d3-interpolate": "^2.0.0",
     "@types/d3-scale": "^3.2.2",
     "@types/d3-selection": "^2.0.0",
     "babel-loader": "^8.2.2",
@@ -28,8 +30,11 @@
     "webpack-dev-server": "^3.11.2"
   },
   "dependencies": {
+    "clsx": "^1.1.1",
     "d3-array": "^2.12.0",
+    "d3-format": "^2.0.0",
     "d3-hierarchy": "^2.0.0",
+    "d3-interpolate": "^2.0.1",
     "d3-scale": "^3.2.3",
     "d3-selection": "^2.0.0"
   }

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -1,3 +1,4 @@
+import { format } from "d3-format";
 import { VisualizationDefinition, VisQueryResponse } from "types/looker";
 
 export interface ValidationOptions {
@@ -71,4 +72,36 @@ export const validateResponse = (
       options.max_measures
     )
   );
+};
+
+export const formatType = (valueFormat: string) => {
+  if (!valueFormat) return format("");
+  let specifier = "";
+  switch (valueFormat.charAt(0)) {
+    case "$":
+      specifier += "$";
+      break;
+    case "£":
+      specifier += "£";
+      break;
+    case "€":
+      specifier += "€";
+      break;
+  }
+  if (valueFormat.indexOf(",") > -1) {
+    specifier += ",";
+  }
+  const splitValueFormat = valueFormat.split(".");
+  specifier += ".";
+  specifier += splitValueFormat.length > 1 ? splitValueFormat[1].length : 0;
+
+  switch (valueFormat.slice(-1)) {
+    case "%":
+      specifier += "%";
+      break;
+    case "0":
+      specifier += "f";
+      break;
+  }
+  return format(specifier);
 };

--- a/src/visualizations/treemap/treemap.css
+++ b/src/visualizations/treemap/treemap.css
@@ -21,3 +21,7 @@ body {
 .label {
   fill: var(--white);
 }
+
+.occluded {
+  visibility: hidden;
+}

--- a/src/visualizations/treemap/treemap.ts
+++ b/src/visualizations/treemap/treemap.ts
@@ -1,8 +1,11 @@
 import { select, Selection } from "d3-selection";
 import { hierarchy, treemap } from "d3-hierarchy";
-import { scaleOrdinal } from "d3-scale";
+import { scaleOrdinal, scaleSequential } from "d3-scale";
+import { interpolateRgbBasis } from "d3-interpolate";
+import { extent } from "d3-array";
+import clsx from "clsx";
 import { VisualizationDefinition, VisData, Row } from "types/looker";
-import { validateResponse } from "common/util";
+import { formatType, validateResponse } from "common/util";
 import "./treemap.css";
 
 interface TreemapVisualization extends VisualizationDefinition {
@@ -58,8 +61,20 @@ const vis: TreemapVisualization = {
       display: "colors",
       default: ["#002060", "#0042C7", "#97BAFF", "#7F7F7F"],
     },
+    gradient: {
+      type: "array",
+      label: "Gradient",
+      display: "colors",
+      default: ["#002060", "#fdea45"],
+    },
+    displayMeasure: {
+      type: "boolean",
+      label: "Display Measure in Labels",
+      display: "boolean",
+      default: true,
+    },
   },
-  create: function (element) {
+  create: function (element, settings) {
     this.frame = select(element)
       .append("svg")
       .attr("width", "100%")
@@ -71,26 +86,41 @@ const vis: TreemapVisualization = {
     validateResponse(this, queryResponse, {
       min_dimensions: 1,
       min_measures: 1,
-      max_measures: 1,
+      max_measures: 2,
     });
     const { clientWidth: width, clientHeight: height } = element;
 
-    const { fontSize, palette } = config;
+    const { fontSize, palette, gradient, displayMeasure } = config;
 
     const {
       dimension_like: dimensions,
-      measure_like: [measure],
+      measure_like: [primaryMeasure, secondaryMeasure],
     } = queryResponse.fields;
+
+    const formatDimension = (value: string | null) =>
+      value === null ? "∅" : value;
+    const formatPrimaryMeasure = formatType(primaryMeasure.value_format);
 
     const root = buildHierarchy(data, dimensions)
       .sum(([_, datum]) =>
-        datum instanceof Map ? 0 : datum[measure.name].value
+        datum instanceof Map ? 0 : datum[primaryMeasure.name].value
       )
       .sort((a, b) => b.value! - a.value!);
 
+    const scaleSecondaryMeasure = scaleSequential(
+      interpolateRgbBasis(gradient || [])
+    );
+
+    if (secondaryMeasure) {
+      const domain = extent(
+        data.map((row) => row[secondaryMeasure.name].value)
+      );
+      scaleSecondaryMeasure.domain(domain as [number, number]);
+    }
+
     const color = scaleOrdinal<string>()
       .domain(root.children!.map((d) => d.data[0]))
-      .range(palette);
+      .range(palette || []);
 
     const layout = treemap<[string, Datum]>()
       .size([width - 2 * margin, height - 2 * margin])
@@ -117,15 +147,39 @@ const vis: TreemapVisualization = {
       .data((d) => d)
       .attr("width", (d) => d.x1 - d.x0)
       .attr("height", (d) => d.y1 - d.y0)
-      .attr("fill", (d) => color(d.ancestors().slice(-2, -1)[0].data[0]));
+      .attr("fill", (d) =>
+        secondaryMeasure && d.height === 0
+          ? scaleSecondaryMeasure(
+              (d.data[1] as Row)[secondaryMeasure.name].value
+            )
+          : color(d.ancestors().slice(-2, -1)[0].data[0])
+      );
 
     const labels = nodes
-      .selectAll(".label")
+      .selectAll<SVGTextElement, Datum>("text.label")
       .data((d) => d)
       .attr("font-size", (d) => fontSize * Math.pow(1.4, d.height))
       .attr("x", fontSize * 0.5)
       .attr("y", "1.1em")
-      .text((node) => `${node.data[0]} (${node.value})`);
+      .text(
+        (node) =>
+          `${formatDimension(node.data[0])} ${
+            displayMeasure ? `(${formatPrimaryMeasure(node.value!)}) ` : ""
+          }`
+      )
+      .attr("class", (_, i, nodes) => {
+        const element = nodes[i];
+        const label = element.getBoundingClientRect();
+        const rect = element
+          .parentElement!.querySelector(".box")!
+          .getBoundingClientRect();
+        const occluded =
+          label.left < rect.left ||
+          label.right > rect.right ||
+          label.top < rect.top ||
+          label.bottom > rect.bottom;
+        return clsx("label", { occluded });
+      });
   },
 };
 


### PR DESCRIPTION
This PR does a few things:

- Hide labels when they do not fit inside their bounding rectangles
- Format values according to measure's configured format string
- add a toggle to config for whether or not to show values in labels
- when a second measure is included, use it to color the leaves on a gradient.

There is significant room for improvement on the approach to coloring. Further iteration will be required for it to really be useful.